### PR TITLE
Removing -fasmblocks default for OS X

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -105,8 +105,8 @@ path="$lib/pure/unidecode"
 @if macosx or freebsd:
   cc = clang
   tlsEmulation:on
-  gcc.options.always = "-w -fasm-blocks"
-  gcc.cpp.options.always = "-w -fasm-blocks -fpermissive"
+  gcc.options.always = "-w"
+  gcc.cpp.options.always = "-w -fpermissive"
 @else:
   gcc.options.always = "-w" 
   gcc.cpp.options.always = "-w -fpermissive"


### PR DESCRIPTION
Considering that alternatives to the Apple compiler versions of xcode like GCC 4.9 (as installed by Homebrew) error out because it is an unknown parameter. Modern Xcode's clang + gcc do not seem to need this anymore. 

I think it is ok to remove because developer with old xcode are rare and can easily add this to their systems if needed.
